### PR TITLE
use version for download url

### DIFF
--- a/Formula/abq.rb
+++ b/Formula/abq.rb
@@ -4,12 +4,12 @@ class Abq < Formula
   version "1.0.1"
 
   if OS.mac? && Hardware::CPU.intel?
-    url "https://abq.build/api/downloads/v1?os=darwin&arch=x86-64", user_agent: :fake
+    url "https://abq.build/api/downloads/#{version}?os=darwin&arch=x86-64", user_agent: :fake
     sha256 "31e7ad9c33127a91baa5d7ea8b11893bca551fc98c88ef1b3bd81bb608af0fa3"
   end
 
   if OS.mac? && Hardware::CPU.arm?
-    url "https://abq.build/api/downloads/v1?os=darwin&arch=aarch64", user_agent: :fake
+    url "https://abq.build/api/downloads/#{version}?os=darwin&arch=aarch64", user_agent: :fake
     sha256 "9fe9ee284c241e1a6e4c69f6c02d59a53433d291f607b4e3aebbb52bed4097b2"
   end
 


### PR DESCRIPTION
use version in url so that updates to the stable release channel don't temporarily invalidate the formula