### PR TITLE
Release Captain v1.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
       matrix:
         include:
           - name: captain
-            version: "1.10.3"
+            version: "1.11.0"
           - name: captain@1
-            version: "1.10.3"
+            version: "1.11.0"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Formula/captain.rb
+++ b/Formula/captain.rb
@@ -1,16 +1,16 @@
 class Captain < Formula
   desc "Captain - CI and Test Analytics"
   homepage "https://captain.build"
-  version "1.10.3"
+  version "1.11.0"
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://releases.captain.build/v#{version}/darwin/x86_64/captain", user_agent: :fake
-    sha256 "3a2b028a04ea9fe81dbaabbbe0d4a0669197914cfa3826a4cd4c219c71c14c5e"
+    sha256 "a25fdc5fcc188d39d4b4cb779c96a4560cc5127cf42c08ff3aff86986dde0681"
   end
 
   if OS.mac? && Hardware::CPU.arm?
     url "https://releases.captain.build/v#{version}/darwin/aarch64/captain", user_agent: :fake
-    sha256 "d2c322db7e773ed30acca193bdee399bdd37b2b6319af07e1ea9929f3ce0f698"
+    sha256 "1d14111d8721c63e1605048140e067fde98dd565344a7f5f23cfbe112e011de9"
   end
 
   def install

--- a/Formula/captain@1.rb
+++ b/Formula/captain@1.rb
@@ -1,16 +1,16 @@
 class CaptainAT1 < Formula
   desc "Captain - CI and Test Analytics"
   homepage "https://captain.build"
-  version "1.10.3"
+  version "1.11.0"
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://releases.captain.build/v#{version}/darwin/x86_64/captain", user_agent: :fake
-    sha256 "3a2b028a04ea9fe81dbaabbbe0d4a0669197914cfa3826a4cd4c219c71c14c5e"
+    sha256 "a25fdc5fcc188d39d4b4cb779c96a4560cc5127cf42c08ff3aff86986dde0681"
   end
 
   if OS.mac? && Hardware::CPU.arm?
     url "https://releases.captain.build/v#{version}/darwin/aarch64/captain", user_agent: :fake
-    sha256 "d2c322db7e773ed30acca193bdee399bdd37b2b6319af07e1ea9929f3ce0f698"
+    sha256 "1d14111d8721c63e1605048140e067fde98dd565344a7f5f23cfbe112e011de9"
   end
 
   def install


### PR DESCRIPTION
Improve DX of captain partition functionality by inferring CI provider parallelism and exposing new configuration to partition w/in captain run.

Release Notes: https://github.com/rwx-research/captain/releases/tag/v1.11.0