### PR TITLE
Extract the development docs into a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,34 @@
-# Homebrew Formulas for RWX apps
+# Homebrew Formulas for RWX tools
 
 ## abq
 
-Use this tap to install [abq](https://abq.build/).
+Use this tap to install [abq](https://www.rwx.com/abq).
 
 ```bash
 brew install rwx-research/tap/abq
 ```
 
-or
+or to pin to major version 1.x use:
 
 ```bash
 brew install rwx-research/tap/abq@1
 ```
 
-to disable major version updates with `brew upgrade`.
-
 ## captain
 
-Install the [Captain](https://captain.build) CLI:
+Install the [Captain](https://www.rwx.com/captain) CLI:
 
 
 ```bash
 brew install rwx-research/tap/captain
 ```
 
-or
+or to pin to major version 1.x use:
 
 ```bash
 brew install rwx-research/tap/captain@1
 ```
 
-to disable major version updates with `brew upgrade`.
+## Development
 
-### Updating the version of ABQ
-
-```sh
-bin/update-abq-formulae X.X.X
-```
-
-This script will:
-- Fetch the old tars
-- SHA256 them
-- Untar them
-- Ensure they produce the expected version
-- Fetch the new tars
-- SHA256 them
-- Untar them
-- Ensure they produce the expected version
-- Replace the old version references with the new version
-- Replace the old SHA256 references with the new ones
-
-### Updating the version of Captain
-
-```sh
-bin/update-captain-formulae X.X.X
-```
-
-This script will:
-- Fetch the old binaries
-- SHA256 them
-- Ensure they produce the expected version
-- Fetch the new binaries
-- SHA256 them
-- Ensure they produce the expected version
-- Replace the old version references with the new version
-- Replace the old SHA256 references with the new ones
+For notes on maintaining this repository, see [development.md](development.md)

--- a/development.md
+++ b/development.md
@@ -1,0 +1,35 @@
+# Development
+
+## Updating the version of ABQ
+
+```sh
+bin/update-abq-formulae X.X.X
+```
+
+This script will:
+- Fetch the old tars
+- SHA256 them
+- Untar them
+- Ensure they produce the expected version
+- Fetch the new tars
+- SHA256 them
+- Untar them
+- Ensure they produce the expected version
+- Replace the old version references with the new version
+- Replace the old SHA256 references with the new ones
+
+## Updating the version of Captain
+
+```sh
+bin/update-captain-formulae X.X.X
+```
+
+This script will:
+- Fetch the old binaries
+- SHA256 them
+- Ensure they produce the expected version
+- Fetch the new binaries
+- SHA256 them
+- Ensure they produce the expected version
+- Replace the old version references with the new version
+- Replace the old SHA256 references with the new ones


### PR DESCRIPTION
I wanted to move this into a separate file so that `README.md` only contains information pertinent to end users.