### PR TITLE
Bump macOS version for CI

### DIFF
--- a/.github/workflows/abq-ci.yml
+++ b/.github/workflows/abq-ci.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   test_abq:
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         include:

--- a/.github/workflows/captain-ci.yml
+++ b/.github/workflows/captain-ci.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   test_captain:
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         include:

--- a/.github/workflows/mint-ci.yml
+++ b/.github/workflows/mint-ci.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   test_mint:
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         include:


### PR DESCRIPTION
macOS 11 is no longer supported:

```
Warning: You are using macOS 11.
We (and Apple) do not provide support for this old version.
```