### PR TITLE
Release Mint v0.1.2

### DIFF
--- a/.github/workflows/captain-ci.yml
+++ b/.github/workflows/captain-ci.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Install captain
         run: |
           set -o pipefail
-          ! command -v abq
+          ! command -v captain
           brew install ${{ matrix.name }}
           captain --version | grep ${{ matrix.version }}

--- a/.github/workflows/mint-ci.yml
+++ b/.github/workflows/mint-ci.yml
@@ -10,10 +10,10 @@ jobs:
       matrix:
         include:
           - name: mint
-            version: "0.1.1"
+            version: "0.1.2"
             os: macos-12 # intel
           - name: mint
-            version: "0.1.1"
+            version: "0.1.2"
             os: macos-14 # arm
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
       matrix:
         include:
           - name: mint
-            version: "0.1.1"
+            version: "0.1.2"
     steps:
       - name: Install homebrew
         uses: Homebrew/actions/setup-homebrew@5caa94335a28d8fdf5a478ae8586f2da40a0a989

--- a/.github/workflows/mint-ci.yml
+++ b/.github/workflows/mint-ci.yml
@@ -42,6 +42,6 @@ jobs:
       - name: Install mint
         run: |
           set -o pipefail
-          ! command -v abq
+          ! command -v mint
           brew install rwx-research/tap/${{ matrix.name }}
           mint --version | grep ${{ matrix.version }}

--- a/Formula/mint.rb
+++ b/Formula/mint.rb
@@ -1,20 +1,20 @@
 class Mint < Formula
   desc "Mint is the CI platform with the best developer experience, powering the fastest builds"
   homepage "https://www.rwx.com/mint"
-  version "0.1.1"
+  version "0.1.2"
 
   if OS.mac?
     if Hardware::CPU.intel?
       url "https://github.com/rwx-research/mint-cli/releases/download/v#{version}/mint-darwin-x86_64", user_agent: :fake
-      sha256 "8c13b18ebad7b2afa7490ea2aabb3c2a21a5090891d56f01543a9fd905f9ddae"
+      sha256 "f6aa35085274d0b2ee9c2ef59a2696307318f685873a39d3c18f5323453a6515"
     elsif Hardware::CPU.arm?
       url "https://github.com/rwx-research/mint-cli/releases/download/v#{version}/mint-darwin-aarch64", user_agent: :fake
-      sha256 "3f3f6617ac327ceeef41cb0c3a1e65e7880c7210d9bcd00b2fc2c4948f4de6ab"
+      sha256 "7db275d35c04aacece53ce17beb1f50a845d8a58721e0107c49509d63e5cf55b"
     end
   else
     if Hardware::CPU.intel?
       url "https://github.com/rwx-research/mint-cli/releases/download/v#{version}/mint-linux-x86_64", user_agent: :fake
-      sha256 "88f46ba7b54d914b63968be346fc0f1002429749683c651f9bc256775aac40df"
+      sha256 "49b2a5f5e2114bb9673d4f51a599f8fd9889757b6c00e2bbf5321952ad13ccb2"
     end
   end
 


### PR DESCRIPTION
https://github.com/rwx-research/mint-cli/releases/tag/v0.1.2

- Bump mint to 0.1.2
- Correct copy/paste typos in tests
