### PR TITLE
Release Captain 1.21.0

### DIFF
--- a/.github/workflows/captain-ci.yml
+++ b/.github/workflows/captain-ci.yml
@@ -10,17 +10,17 @@ jobs:
       matrix:
         include:
           - name: captain
-            version: "1.20.0"
+            version: "1.21.0"
             os: macos-13 # intel
           - name: captain
-            version: "1.20.0"
+            version: "1.21.0"
             os: macos-14 # arm
 
           - name: captain@1
-            version: "1.20.0"
+            version: "1.21.0"
             os: macos-13 # intel
           - name: captain@1
-            version: "1.20.0"
+            version: "1.21.0"
             os: macos-14 # arm
 
     steps:
@@ -43,9 +43,9 @@ jobs:
       matrix:
         include:
           - name: captain
-            version: "1.20.0"
+            version: "1.21.0"
           - name: captain@1
-            version: "1.20.0"
+            version: "1.21.0"
     steps:
       - name: Install homebrew
         uses: Homebrew/actions/setup-homebrew@5caa94335a28d8fdf5a478ae8586f2da40a0a989

--- a/Formula/captain.rb
+++ b/Formula/captain.rb
@@ -1,20 +1,20 @@
 class Captain < Formula
   desc "Captain can detect and quarantine flaky tests, automatically retry failed tests, partition files for parallel execution, and more"
   homepage "https://www.rwx.com/captain"
-  version "1.20.0"
+  version "1.21.0"
 
   if OS.mac?
     if Hardware::CPU.intel?
       url "https://releases.captain.build/v#{version}/darwin/x86_64/captain", user_agent: :fake
-      sha256 "388685779dee0a6dd8e2fb688f0de19c9809064be327d6fea9f28804313a813e"
+      sha256 "02d6d0ec113bc84204362beb790431512f8bfb5731bb6253429f8567a7c5276f"
     elsif Hardware::CPU.arm?
       url "https://releases.captain.build/v#{version}/darwin/aarch64/captain", user_agent: :fake
-      sha256 "7c4e1e01944af333ff888e3789d36c35a61b8dcfa248ee1e2ad7c158afae1ab6"
+      sha256 "2b857ef7ce111753305da727d15ebfb137053e0ac368e7619fe3585f465d7827"
     end
   else
     if Hardware::CPU.intel?
       url "https://releases.captain.build/v#{version}/linux/x86_64/captain", user_agent: :fake
-      sha256 "734e24b1dc5ca1680de51dff3e2894890a2c87c53b3eb9e6f234cfa7d76d2341"
+      sha256 "8f483a0eb9a6df04520c9f027ddf76a830d129c65718eebd441dda1a20e36d97"
     end
   end
 

--- a/Formula/captain@1.rb
+++ b/Formula/captain@1.rb
@@ -1,20 +1,20 @@
 class CaptainAT1 < Formula
   desc "Captain can detect and quarantine flaky tests, automatically retry failed tests, partition files for parallel execution, and more"
   homepage "https://www.rwx.com/captain"
-  version "1.20.0"
+  version "1.21.0"
 
   if OS.mac?
     if Hardware::CPU.intel?
       url "https://releases.captain.build/v#{version}/darwin/x86_64/captain", user_agent: :fake
-      sha256 "388685779dee0a6dd8e2fb688f0de19c9809064be327d6fea9f28804313a813e"
+      sha256 "02d6d0ec113bc84204362beb790431512f8bfb5731bb6253429f8567a7c5276f"
     elsif Hardware::CPU.arm?
       url "https://releases.captain.build/v#{version}/darwin/aarch64/captain", user_agent: :fake
-      sha256 "7c4e1e01944af333ff888e3789d36c35a61b8dcfa248ee1e2ad7c158afae1ab6"
+      sha256 "2b857ef7ce111753305da727d15ebfb137053e0ac368e7619fe3585f465d7827"
     end
   else
     if Hardware::CPU.intel?
       url "https://releases.captain.build/v#{version}/linux/x86_64/captain", user_agent: :fake
-      sha256 "734e24b1dc5ca1680de51dff3e2894890a2c87c53b3eb9e6f234cfa7d76d2341"
+      sha256 "8f483a0eb9a6df04520c9f027ddf76a830d129c65718eebd441dda1a20e36d97"
     end
   end
 


### PR DESCRIPTION
Reduce output for tests that aren't failed (only include failure summary).

[Release notes](https://github.com/rwx-research/captain/releases/tag/v1.21.0)